### PR TITLE
YouTube ECL Provider with google youtube v3

### DIFF
--- a/Blocks.Tridion.ECL.YouTube.Tests/Blocks.Tridion.ECL.YouTube.Tests.csproj
+++ b/Blocks.Tridion.ECL.YouTube.Tests/Blocks.Tridion.ECL.YouTube.Tests.csproj
@@ -32,17 +32,39 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Google.GData.Client">
-      <HintPath>..\packages\Google.GData.Client.2.1.0.0\lib\Google.GData.Client.dll</HintPath>
+    <Reference Include="Google.Apis">
+      <HintPath>..\packages\Google.Apis.1.9.0\lib\net40\Google.Apis.dll</HintPath>
     </Reference>
-    <Reference Include="Google.GData.Extensions">
-      <HintPath>..\packages\Google.GData.Extensions.2.1.0.0\lib\Google.GData.Extensions.dll</HintPath>
+    <Reference Include="Google.Apis.Auth">
+      <HintPath>..\packages\Google.Apis.Auth.1.9.0\lib\net40\Google.Apis.Auth.dll</HintPath>
     </Reference>
-    <Reference Include="Google.GData.YouTube">
-      <HintPath>..\packages\Google.GData.YouTube.2.1.0.0\lib\Google.GData.YouTube.dll</HintPath>
+    <Reference Include="Google.Apis.Auth.PlatformServices">
+      <HintPath>..\packages\Google.Apis.Auth.1.9.0\lib\net40\Google.Apis.Auth.PlatformServices.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.4.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Google.Apis.Core">
+      <HintPath>..\packages\Google.Apis.Core.1.9.0\lib\portable-net40+sl50+win+wpa81+wp80\Google.Apis.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Google.Apis.PlatformServices">
+      <HintPath>..\packages\Google.Apis.1.9.0\lib\net40\Google.Apis.PlatformServices.dll</HintPath>
+    </Reference>
+    <Reference Include="Google.Apis.YouTube.v3">
+      <HintPath>..\packages\Google.Apis.YouTube.v3.1.9.0.1370\lib\portable-net40+sl50+win+wpa81+wp80\Google.Apis.YouTube.v3.dll</HintPath>
+    </Reference>
+    <Reference Include="log4net">
+      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.2.12296, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -53,7 +75,34 @@
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="System.IO">
+      <HintPath>..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.IO.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http, Version=2.2.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\net40\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Extensions">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\net40\System.Net.Http.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Primitives">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\net40\System.Net.Http.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest, Version=2.2.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\net40\System.Net.Http.WebRequest.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime">
+      <HintPath>..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks">
+      <HintPath>..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Threading.Tasks.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
+    <Reference Include="Zlib.Portable">
+      <HintPath>..\packages\Zlib.Portable.1.10.0\lib\portable-net4+sl5+wp8+win8+wpa81+MonoTouch+MonoAndroid\Zlib.Portable.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -76,6 +125,11 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Blocks.Tridion.ECL.YouTube.Tests/ExternalContentLibrary.xml
+++ b/Blocks.Tridion.ECL.YouTube.Tests/ExternalContentLibrary.xml
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Configuration xmlns="http://www.sdltridion.com/ExternalContentLibrary/Configuration">
+  <!-- Available logging levels: Debug, Info, Warning, Error -->
+  <l:Logging Level="Warning" xmlns:l="http://www.sdltridion.com/Infrastructure/LoggingConfiguration">
+    <!-- Additional supported attributes: Language="rfc1766 code" Locale="rfc1766 code". An example of an rfc1766 code is "de-DE" for German. /-->
+    <!-- <l:Folder>Full path to logging folder, default is %TRIDION%/bin/log</l:Folder>-->
+  </l:Logging>
+  <CoreServiceUrl>net.tcp://localhost:2660/CoreService/2011/netTcp</CoreServiceUrl>
+  <MountPoints>
+    <MountPoint type="YouTubeProvider" version="*" id="youtube" rootItemName="YouTube">
+      <StubFolders>
+        <StubFolder id="tcm:1-3-2" />
+      </StubFolders>
+      <PrivilegedUserName>DOMAIN\user</PrivilegedUserName>
+      <AppName xmlns="http://gdata.youtube.com/schemas/2007">Your YouTube App Name</AppName>
+      <ApiKey xmlns="http://gdata.youtube.com/schemas/2007">Your Google API Key</ApiKey>
+      <Users xmlns="http://gdata.youtube.com/schemas/2007">
+        <User></User>
+        <User></User>
+      </Users>
+      <ProxyURI xmlns="http://gdata.youtube.com/schemas/2007">Proxy Address</ProxyURI>
+      <ProxyUser xmlns="http://gdata.youtube.com/schemas/2007">Proxy Username </ProxyUser>
+      <ProxyPassword xmlns="http://gdata.youtube.com/schemas/2007">Proxy Password</ProxyPassword>
+    </MountPoint>
+  </MountPoints>
+</Configuration>

--- a/Blocks.Tridion.ECL.YouTube.Tests/YouTubeClientTests.cs
+++ b/Blocks.Tridion.ECL.YouTube.Tests/YouTubeClientTests.cs
@@ -17,9 +17,8 @@ namespace Blocks.Tridion.ECL.YouTube.Tests
             var appSettings = ConfigurationManager.AppSettings;
 
             _client = new YouTubeClient(appSettings["AppName"],
-                                        appSettings["DeveloperKey"],
-                                        appSettings["Username"], 
-                                        appSettings["Password"]);
+                                        appSettings["ApiKey"],
+                                        appSettings["Username"]);
         }
 
         [Test]
@@ -28,15 +27,6 @@ namespace Blocks.Tridion.ECL.YouTube.Tests
             _client.UserToDisplay = "BadLipReading";
 
             var videos = _client.GetUploadsForUser();
-
-            Assert.That(videos, Is.Not.Null);
-            Assert.That(videos, Is.Not.Empty);
-        }
-
-        [Test]
-        public void Can_get_popular_videos()
-        {
-            var videos = _client.GetMostPopular();
 
             Assert.That(videos, Is.Not.Null);
             Assert.That(videos, Is.Not.Empty);

--- a/Blocks.Tridion.ECL.YouTube.Tests/packages.config
+++ b/Blocks.Tridion.ECL.YouTube.Tests/packages.config
@@ -1,8 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Google.GData.Client" version="2.1.0.0" targetFramework="net40" />
-  <package id="Google.GData.Extensions" version="2.1.0.0" targetFramework="net40" />
-  <package id="Google.GData.YouTube" version="2.1.0.0" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="4.0.8" targetFramework="net40" />
+  <package id="Google.Apis" version="1.9.0" targetFramework="net40" />
+  <package id="Google.Apis.Auth" version="1.9.0" targetFramework="net40" />
+  <package id="Google.Apis.Core" version="1.9.0" targetFramework="net40" />
+  <package id="Google.Apis.YouTube.v3" version="1.9.0.1370" targetFramework="net40" />
+  <package id="log4net" version="2.0.3" targetFramework="net40" />
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net40" />
+  <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net40" />
   <package id="NUnit" version="2.6.2" targetFramework="net40" />
+  <package id="Zlib.Portable" version="1.10.0" targetFramework="net40" />
 </packages>

--- a/Blocks.Tridion.ECL.YouTube/API/Video.cs
+++ b/Blocks.Tridion.ECL.YouTube/API/Video.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Google.Apis.YouTube.v3.Data;
+
+namespace Blocks.Tridion.ECL.YouTube.API
+{
+    public class Video
+    {
+        public Video(PlaylistItem result)
+        {
+            VideoId = result.Snippet.ResourceId.VideoId;
+            Title = result.Snippet.Title;
+            Uploader = "";
+            Description = result.Snippet.Description;
+            //Type=result.Snippet.
+            Thumbnail = result.Snippet.Thumbnails.Default.Url;
+            ThumbnailETag = result.Snippet.Thumbnails.ETag;
+        }
+
+        public Video(SearchResult result)
+        {
+            VideoId = result.Id.VideoId;
+            Title = result.Snippet.Title;
+            Uploader = "";
+            Description = result.Snippet.Description;
+            //Type=result
+            Thumbnail = result.Snippet.Thumbnails.Default.Url;
+            ThumbnailETag = result.Snippet.Thumbnails.ETag;
+        }
+
+        public DateTime? Published { get; set; }
+        public string Title { get; set; }
+        public string Uploader { get; set; }
+        public string Description { get; set; }
+        public string VideoId { get; set; }
+        public string Type { get; set; }
+
+        public string Thumbnail { get; set; }
+        public string ThumbnailETag { get; set; }
+    }
+}

--- a/Blocks.Tridion.ECL.YouTube/API/YouTubeClient.cs
+++ b/Blocks.Tridion.ECL.YouTube/API/YouTubeClient.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Google.GData.YouTube;
-using Google.YouTube;
+using System.Net;
+using Google.Apis.Services;
+using Google.Apis.YouTube.v3;
+using log4net.Repository.Hierarchy;
 
 namespace Blocks.Tridion.ECL.YouTube.API
 {
@@ -11,25 +13,50 @@ namespace Blocks.Tridion.ECL.YouTube.API
     /// </summary>
     public class YouTubeClient
     {
-        private readonly YouTubeRequestSettings _settings;
+        private readonly YouTubeService _youTubeService;
         private readonly string _userName;
 
+        public WebProxy _proxy { get; set; }
         public string UserToDisplay { get; set; }
+        public List<string> Users { get; set; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="YouTubeClient"/> class.
+        /// 
         /// </summary>
-        /// <param name="appName">The YouTube Application Name</param>
-        /// <param name="developerKey">The YouTube Developer Key</param>
-        /// <param name="userName">The YouTube Username</param>
-        /// <param name="password">The YouTube Password.</param>
-        public YouTubeClient(string appName, string developerKey, string userName, string password)
+        /// <param name="appName"></param>
+        /// <param name="apiKey"></param>
+        /// <param name="userName"></param>
+        public YouTubeClient(string appName, string apiKey, string userName)
         {
-            _settings = new YouTubeRequestSettings(appName, developerKey, userName, password);
-            _settings.AutoPaging = true;
-
+            _youTubeService = new YouTubeService(
+                new BaseClientService.Initializer()
+                {
+                    ApplicationName = appName,
+                    ApiKey = apiKey
+                });
             _userName = userName;
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="YouTubeClient"/> class with proxy .
+        /// </summary>
+        /// <param name="appName"></param>
+        /// <param name="apiKey"></param>
+        /// <param name="userName"></param>
+        /// <param name="proxy"></param>
+        public YouTubeClient(string appName, string apiKey, string userName, WebProxy proxy)
+        {
+            _youTubeService = new YouTubeService(
+                 new BaseClientService.Initializer()
+                 {
+                     ApplicationName = appName,
+                     ApiKey = apiKey
+                 });
+            _userName = userName;
+            _proxy = proxy;
+
+        }
+
 
         /// <summary>
         /// Retrieves a list of videos uploaded by the configured user.
@@ -38,18 +65,72 @@ namespace Blocks.Tridion.ECL.YouTube.API
         {
             try
             {
-                var userName = _userName;
-                if (!string.IsNullOrEmpty(UserToDisplay))
-                    userName = UserToDisplay;
-
-                var request = new YouTubeRequest(_settings);
-                var uri = new Uri("http://gdata.youtube.com/feeds/api/users/{0}/uploads".FormatWith(userName));
-
-                var feed = request.Get<Video>(uri);
-
-                return feed.Entries.ToList();
+                List<Video> videos = new List<Video>();
+                var channelsListRequest = _youTubeService.Channels.List("contentDetails");
+                channelsListRequest.ForUsername = _userName;
+                var channelsListResponse = channelsListRequest.Execute();
+                foreach (var channel in channelsListResponse.Items)
+                {
+                    var uploadsListId = channel.ContentDetails.RelatedPlaylists.Uploads;
+                    var playlistItemsListRequest = _youTubeService.PlaylistItems.List("snippet");
+                    playlistItemsListRequest.PlaylistId = uploadsListId;
+                    playlistItemsListRequest.MaxResults = 50;
+                    //playlistItemsListRequest.PageToken = "";
+                    var playlistItemsListResponse = playlistItemsListRequest.Execute();
+                    videos.AddRange(playlistItemsListResponse.Items.Select(x => new Video(x)));
+                }
+                return videos;
             }
-            catch
+            catch (Exception ex)
+            {
+                return new List<Video>();
+            }
+        }
+
+        /// <summary>
+        /// GetUploadsForUser
+        /// </summary>
+        /// <param name="user"></param>
+        /// <param name="pageIndex"></param>
+        /// <param name="totalVideos"></param>
+        /// <returns></returns>
+        public IList<Video> GetUploadsForUser(string user, int pageIndex, out int totalVideos)
+        {
+            totalVideos = 0;
+            try
+            {
+                List<Video> videos = new List<Video>();
+                var channelsListRequest = _youTubeService.Channels.List("contentDetails");
+                channelsListRequest.ForUsername = user;
+                var channelsListResponse = channelsListRequest.Execute();
+                string pageToken = " ";
+                foreach (var channel in channelsListResponse.Items)
+                {
+                    //TODO: This loop is to find the pageToken, If you find a better option DO IT
+                    for (int page = 0; page <= pageIndex; page++)
+                    {
+                        var uploadsListId = channel.ContentDetails.RelatedPlaylists.Uploads;
+                        var playlistItemsListRequest = _youTubeService.PlaylistItems.List("snippet");
+                        playlistItemsListRequest.PlaylistId = uploadsListId;
+                        playlistItemsListRequest.MaxResults = 50;
+                        playlistItemsListRequest.PageToken = pageToken;
+                        var playlistItemsListResponse = playlistItemsListRequest.Execute();
+                        pageToken = playlistItemsListResponse.NextPageToken;
+                        
+                        if (playlistItemsListResponse.PageInfo.TotalResults != null)
+                            totalVideos = playlistItemsListResponse.PageInfo.TotalResults.Value;
+                        if (page == pageIndex)
+                        {
+                            videos.AddRange(playlistItemsListResponse.Items.Select(x => new Video(x)));
+                        }
+                    }
+
+
+
+                }
+                return videos;
+            }
+            catch (Exception ex)
             {
                 return new List<Video>();
             }
@@ -63,12 +144,12 @@ namespace Blocks.Tridion.ECL.YouTube.API
         {
             try
             {
-                var request = new YouTubeRequest(_settings);
-                var uri = new Uri("http://gdata.youtube.com/feeds/api/videos/{0}".FormatWith(id));
-
-                var video = request.Retrieve<Video>(uri);
-
-                return video;
+                var search = _youTubeService.Search.List("id,snippet");
+                search.Q = id;
+                var result = search.Execute();
+                var video = result.Items.FirstOrDefault();
+                if (video == null) return null;
+                return (new Video(video));
             }
             catch
             {
@@ -76,48 +157,48 @@ namespace Blocks.Tridion.ECL.YouTube.API
             }
         }
 
-        /// <summary>
-        /// Retrieves the current most popular videos on YouTube.
-        /// </summary>
-        public IList<Video> GetMostPopular()
-        {
-            try
-            {
-                var request = new YouTubeRequest(_settings);
-                var feed = request.GetStandardFeed(YouTubeQuery.MostPopular);
+        ///// <summary>
+        ///// Retrieves the current most popular videos on YouTube.
+        ///// </summary>
+        //public IList<Video> GetMostPopular()
+        //{
+        //    try
+        //    {
+        //        var request = new YouTubeRequest(_youTubeService);
+        //        if (_proxy != null)
+        //        {
+        //            request.Proxy = _proxy;
+        //        }
+        //        var feed = request.GetStandardFeed(YouTubeQuery.MostPopular);
 
-                return feed.Entries.ToList();
-            }
-            catch
-            {
-                return new List<Video>();
-            }
-        } 
+        //        return feed.Entries.ToList();
+        //    }
+        //    catch (Exception ex)
+        //    {
+        //        return new List<Video>();
+        //    }
+        //}
 
-        /// <summary>
-        /// Performs a search of YouTube videos.
-        /// </summary>
-        /// <param name="terms">The query to search for.</param>
+        ///// <summary>
+        ///// Performs a search of YouTube videos.
+        ///// </summary>
+        ///// <param name="terms">The query to search for.</param>
         public IList<Video> Search(string terms)
         {
             try
             {
-                var request = new YouTubeRequest(_settings);
-                var query = new YouTubeQuery(YouTubeQuery.DefaultVideoUri)
-                {
-                    OrderBy = "viewCount",
-                    Query = terms,
-                    SafeSearch = YouTubeQuery.SafeSearchValues.None
-                };
+                List<Video> videos = new List<Video>();
+                var search = _youTubeService.Search.List("snippet");
+                search.Q = terms;
+                var result = search.Execute();
+                videos.AddRange(result.Items.Select(x => new Video(x)));
+                return videos;
 
-                var feed = request.Get<Video>(query);
-
-                return feed.Entries.ToList();
             }
-            catch
+            catch (Exception ex)
             {
                 return new List<Video>();
             }
-        } 
+        }
     }
 }

--- a/Blocks.Tridion.ECL.YouTube/Blocks.Tridion.ECL.YouTube.csproj
+++ b/Blocks.Tridion.ECL.YouTube/Blocks.Tridion.ECL.YouTube.csproj
@@ -18,7 +18,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\..\..\..\ProgramData\SDL\SDL Tridion\External Content Library\AddInPipeline\AddIns\YoutubeProvider\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/Blocks.Tridion.ECL.YouTube/Blocks.Tridion.ECL.YouTube.csproj
+++ b/Blocks.Tridion.ECL.YouTube/Blocks.Tridion.ECL.YouTube.csproj
@@ -32,31 +32,83 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Google.GData.Client">
-      <HintPath>..\packages\Google.GData.Client.2.1.0.0\lib\Google.GData.Client.dll</HintPath>
+    <Reference Include="Google.Apis">
+      <HintPath>..\packages\Google.Apis.1.9.0\lib\net40\Google.Apis.dll</HintPath>
     </Reference>
-    <Reference Include="Google.GData.Extensions">
-      <HintPath>..\packages\Google.GData.Extensions.2.1.0.0\lib\Google.GData.Extensions.dll</HintPath>
+    <Reference Include="Google.Apis.Auth">
+      <HintPath>..\packages\Google.Apis.Auth.1.9.0\lib\net40\Google.Apis.Auth.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Google.GData.YouTube">
-      <HintPath>..\packages\Google.GData.YouTube.2.1.0.0\lib\Google.GData.YouTube.dll</HintPath>
+    <Reference Include="Google.Apis.Auth.PlatformServices">
+      <HintPath>..\packages\Google.Apis.Auth.1.9.0\lib\net40\Google.Apis.Auth.PlatformServices.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.4.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Google.Apis.Core">
+      <HintPath>..\packages\Google.Apis.Core.1.9.0\lib\portable-net40+sl50+win+wpa81+wp80\Google.Apis.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Google.Apis.PlatformServices">
+      <HintPath>..\packages\Google.Apis.1.9.0\lib\net40\Google.Apis.PlatformServices.dll</HintPath>
+    </Reference>
+    <Reference Include="Google.Apis.YouTube.v3">
+      <HintPath>..\packages\Google.Apis.YouTube.v3.1.9.0.1370\lib\portable-net40+sl50+win+wpa81+wp80\Google.Apis.YouTube.v3.dll</HintPath>
+    </Reference>
+    <Reference Include="log4net">
+      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.AddIn" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="System.IO">
+      <HintPath>..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.IO.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http, Version=2.2.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\net40\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Extensions">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\net40\System.Net.Http.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Primitives">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\net40\System.Net.Http.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest, Version=2.2.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\net40\System.Net.Http.WebRequest.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime">
+      <HintPath>..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks">
+      <HintPath>..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Tridion.ExternalContentLibrary.V2">
-      <HintPath>..\..\lib\Tridion.ExternalContentLibrary.V2.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\..\Workspace\Indivirtual\Framework\References\Tridion 2013\Tridion.ExternalContentLibrary.V2.dll</HintPath>
+    </Reference>
+    <Reference Include="Zlib.Portable">
+      <HintPath>..\packages\Zlib.Portable.1.10.0\lib\portable-net4+sl5+wp8+win8+wpa81+MonoTouch+MonoAndroid\Zlib.Portable.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="API\Video.cs" />
     <Compile Include="API\YouTubeClient.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="Extensions\TemplateAttributeExtensions.cs" />
@@ -65,9 +117,6 @@
     <Compile Include="YouTubeMountPoint.cs" />
     <Compile Include="YouTubeProvider.cs" />
     <Compile Include="YouTubeVideo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Config\ExternalContentLibrary.xml" />
@@ -84,6 +133,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
@@ -91,6 +144,11 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Blocks.Tridion.ECL.YouTube/Config/ExternalContentLibrary.xml
+++ b/Blocks.Tridion.ECL.YouTube/Config/ExternalContentLibrary.xml
@@ -11,12 +11,19 @@
             <StubFolders>
                 <StubFolder id="tcm:1-3-2" />
             </StubFolders>
-            <PrivilegedUserName>BUILDINGBLOCKS\jsimm</PrivilegedUserName>
+            <PrivilegedUserName>DOMAIN\user</PrivilegedUserName>
             <AppName xmlns="http://gdata.youtube.com/schemas/2007">Your YouTube App Name</AppName>
-            <DeveloperKey xmlns="http://gdata.youtube.com/schemas/2007">Your YouTube Developer Key</DeveloperKey>
+            <ApiKey xmlns="http://gdata.youtube.com/schemas/2007">Your YouTube Developer Key</ApiKey>
             <Username xmlns="http://gdata.youtube.com/schemas/2007">Your YouTube/Google Username</Username>
             <Password xmlns="http://gdata.youtube.com/schemas/2007">Your YouTube/Google Password</Password>
-            <UserToDisplay xmlns="http://gdata.youtube.com/schemas/2007">BadLipReading</UserToDisplay>
+            <Users xmlns="http://gdata.youtube.com/schemas/2007">
+              <User></User>
+              <User></User>
+            </Users>
+          <!--Use these entries only if you need to use proxy settings-->
+            <ProxyURI xmlns="http://gdata.youtube.com/schemas/2007">Proxy Address</ProxyURI>
+            <ProxyUser xmlns="http://gdata.youtube.com/schemas/2007">Proxy Username </ProxyUser>
+            <ProxyPassword xmlns="http://gdata.youtube.com/schemas/2007">Proxy Password</ProxyPassword>
         </MountPoint>
     </MountPoints>
 </Configuration>

--- a/Blocks.Tridion.ECL.YouTube/Extensions/TemplateAttributeExtensions.cs
+++ b/Blocks.Tridion.ECL.YouTube/Extensions/TemplateAttributeExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Google.GData.Client;
+using System.Web;
 using Tridion.ExternalContentLibrary.V2;
 
 namespace Blocks.Tridion.ECL.YouTube

--- a/Blocks.Tridion.ECL.YouTube/YouTubeListItem.cs
+++ b/Blocks.Tridion.ECL.YouTube/YouTubeListItem.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using Google.YouTube;
+﻿using Blocks.Tridion.ECL.YouTube.API;
+using System;
 using Tridion.ExternalContentLibrary.V2;
 
 namespace Blocks.Tridion.ECL.YouTube
@@ -7,17 +7,31 @@ namespace Blocks.Tridion.ECL.YouTube
     public class YouTubeListItem : IContentLibraryListItem
     {
         protected readonly Video Video;
+        private String User;
         private readonly IEclUri _id;
+        bool IsVideo = false;
+
+        private string _displayTypeId;
 
         public YouTubeListItem(int publicationId, Video video)
         {
             Video = video;
-            _id = YouTubeProvider.HostServices.CreateEclUri(publicationId, YouTubeProvider.MountPointId, Video.VideoId, DisplayTypeId, EclItemTypes.File);
+            _id = YouTubeProvider.HostServices.CreateEclUri(publicationId, YouTubeProvider.MountPointId, Video.VideoId, "vid", EclItemTypes.File);
+            IsVideo = true;
+            _displayTypeId = "vid";
+        }
+
+        public YouTubeListItem(int publicationId, String user)
+        {
+            User = user;
+            _id = YouTubeProvider.HostServices.CreateEclUri(publicationId, YouTubeProvider.MountPointId, user, "usr", EclItemTypes.Folder);
+            _displayTypeId = "usr";
+            IsVideo = false;
         }
 
         public bool CanGetUploadMultimediaItemsUrl
         {
-            get { return true; }
+            get { return false; }
         }
 
         public bool CanSearch
@@ -27,7 +41,7 @@ namespace Blocks.Tridion.ECL.YouTube
 
         public string DisplayTypeId
         {
-            get { return "vid"; }
+            get { return _displayTypeId; }
         }
 
         public string IconIdentifier
@@ -42,22 +56,48 @@ namespace Blocks.Tridion.ECL.YouTube
 
         public bool IsThumbnailAvailable
         {
-            get { return Video.Thumbnails.Count > 0; }
+
+            get
+            {
+                if (IsVideo)
+                    return Video.Thumbnail != null;
+                else
+                    return false;
+            }
         }
 
         public DateTime? Modified
         {
-            get { return Video.AtomEntry.Published; }
+            get
+            {
+                if (IsVideo)
+                    return Video.Published;
+                return null;
+
+            }
         }
 
         public string ThumbnailETag
         {
-            get { return Video.ETag; }
+            get
+            {
+                if (IsVideo)
+                    return Video.ThumbnailETag;
+                else
+                    return "";
+
+            }
         }
 
         public string Title
         {
-            get { return Video.Title; }
+            get
+            {
+                if (IsVideo)
+                    return Video.Title;
+                else
+                    return User;
+            }
             set { throw new NotSupportedException(); }
         }
 

--- a/Blocks.Tridion.ECL.YouTube/YouTubeProvider.cs
+++ b/Blocks.Tridion.ECL.YouTube/YouTubeProvider.cs
@@ -72,8 +72,7 @@ namespace Blocks.Tridion.ECL.YouTube
                                        config.Element(Namespace + "Username").Value,
                                        proxy)
             {
-                Users = youtubeUsers,
-                UserToDisplay = config.Element(Namespace + "UserToDisplay").Value
+                Users = youtubeUsers                
             };
         }
 

--- a/Blocks.Tridion.ECL.YouTube/YouTubeProvider.cs
+++ b/Blocks.Tridion.ECL.YouTube/YouTubeProvider.cs
@@ -2,6 +2,8 @@
 using System.AddIn;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Net;
 using System.Reflection;
 using System.Xml.Linq;
 using Blocks.Tridion.ECL.YouTube.API;
@@ -33,16 +35,44 @@ namespace Blocks.Tridion.ECL.YouTube
         {
             MountPointId = mountPointId;
             HostServices = hostServices;
-
             var config = XElement.Parse(configurationXmlElement);
 
-            
+            var usersList = config.Element(Namespace + "Users");
+
+            var youtubeUsers = usersList.Elements(Namespace + "User").Select(xUsers => xUsers.Value).ToList();
+
+            var proxyURI = String.Empty;
+            var proxyUser = String.Empty;
+            var proxyPassword = String.Empty;
+
+            WebProxy proxy = new WebProxy();
+
+            if (config.Element(Namespace + "ProxyURI") != null)
+            {
+                proxyURI = config.Element(Namespace + "ProxyURI").Value;
+                proxy = new WebProxy(proxyURI, true);
+            }
+            if (config.Element(Namespace + "ProxyUser") != null)
+            {
+                proxyUser = config.Element(Namespace + "ProxyUser").Value;
+            }
+            if (config.Element(Namespace + "ProxyPassword") != null)
+            {
+                proxyPassword = config.Element(Namespace + "ProxyPassword").Value;
+            }
+
+            if (!String.IsNullOrEmpty(proxyUser) && !String.IsNullOrEmpty(proxyPassword))
+            {
+                proxy.Credentials = new NetworkCredential(proxyUser, proxyPassword);
+            }
+
 
             Client = new YouTubeClient(config.Element(Namespace + "AppName").Value,
-                                       config.Element(Namespace + "DeveloperKey").Value,
+                                       config.Element(Namespace + "ApiKey").Value,
                                        config.Element(Namespace + "Username").Value,
-                                       config.Element(Namespace + "Password").Value)
+                                       proxy)
             {
+                Users = youtubeUsers,
                 UserToDisplay = config.Element(Namespace + "UserToDisplay").Value
             };
         }
@@ -53,12 +83,13 @@ namespace Blocks.Tridion.ECL.YouTube
             {
                 return new List<IDisplayType>
                 {
+                    HostServices.CreateDisplayType("usr", "YouTube User", EclItemTypes.Folder),
                     HostServices.CreateDisplayType("vid", "YouTube Video", EclItemTypes.File)
                 };
             }
         }
 
-        public void Dispose() {}
+        public void Dispose() { }
 
         internal static string AddInFolder
         {

--- a/Blocks.Tridion.ECL.YouTube/YouTubeVideo.cs
+++ b/Blocks.Tridion.ECL.YouTube/YouTubeVideo.cs
@@ -1,15 +1,21 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Google.YouTube;
+using System.Net;
+using Blocks.Tridion.ECL.YouTube.API;
+using Google.Apis.Services;
+using Google.Apis.YouTube.v3;
 using Tridion.ExternalContentLibrary.V2;
 
 namespace Blocks.Tridion.ECL.YouTube
 {
+    /// <summary>
+    /// Client for accessing the YouTube API.
+    /// </summary>
     public class YouTubeVideo : YouTubeListItem, IContentLibraryMultimediaItem
     {
         public YouTubeVideo(int publicationId, Video video)
-            : base(publicationId, video) {}
+            : base(publicationId, video) { }
 
         public IContentLibraryItem Save(bool readback)
         {
@@ -33,7 +39,7 @@ namespace Blocks.Tridion.ECL.YouTube
 
         public DateTime? Created
         {
-            get { return Video.AtomEntry.Published; }
+            get { return Video.Published; }
         }
 
         public string CreatedBy
@@ -53,7 +59,7 @@ namespace Blocks.Tridion.ECL.YouTube
 
         public ISchemaDefinition MetadataXmlSchema
         {
-            get 
+            get
             {
                 var schema = YouTubeProvider.HostServices.CreateSchemaDefinition("Metadata", "http://gdata.youtube.com/schemas/2007");
                 schema.Fields.Add(YouTubeProvider.HostServices.CreateMultiLineTextFieldDefinition("Description", "Description", 0, 1, 7));
@@ -88,7 +94,7 @@ namespace Blocks.Tridion.ECL.YouTube
 
         public string GetTemplateFragment(IList<ITemplateAttribute> attributes)
         {
-            var supportedAttributeNames = new[] {"width", "height"};
+            var supportedAttributeNames = new[] { "width", "height" };
             var supportedAttributes = attributes.SupportedAttributes(supportedAttributeNames);
 
             return "<iframe src=\"{0}\" {1}></iframe>".FormatWith(GetDirectLinkToPublished(attributes), supportedAttributes);
@@ -106,10 +112,9 @@ namespace Blocks.Tridion.ECL.YouTube
 
         public string MimeType
         {
-            get 
-            { 
-                var content = Video.Contents.FirstOrDefault();
-                return content != null ? content.Type : "application/x-shockwave-flash";
+            get
+            {
+                return Video.Type ?? "application/x-shockwave-flash";
             }
         }
 

--- a/Blocks.Tridion.ECL.YouTube/app.config
+++ b/Blocks.Tridion.ECL.YouTube/app.config
@@ -1,16 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <appSettings>
-        <add key="AppName" value="Youtube" />
-        <add key="ApiKey" value="Your Google Api Key" />
-        <add key="Username" value="Your YouTube/Google Username" />
-    </appSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.8.0" newVersion="4.0.8.0" />
-      </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.6.9.0" newVersion="2.6.9.0" />

--- a/Blocks.Tridion.ECL.YouTube/packages.config
+++ b/Blocks.Tridion.ECL.YouTube/packages.config
@@ -1,7 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Google.GData.Client" version="2.1.0.0" targetFramework="net40" />
-  <package id="Google.GData.Extensions" version="2.1.0.0" targetFramework="net40" />
-  <package id="Google.GData.YouTube" version="2.1.0.0" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="4.0.8" targetFramework="net40" />
+  <package id="Google.Apis" version="1.9.0" targetFramework="net40" />
+  <package id="Google.Apis.Auth" version="1.9.0" targetFramework="net40" />
+  <package id="Google.Apis.Core" version="1.9.0" targetFramework="net40" />
+  <package id="Google.Apis.YouTube.v3" version="1.9.0.1370" targetFramework="net40" />
+  <package id="log4net" version="2.0.3" targetFramework="net40" />
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net40" />
+  <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net40" />
+  <package id="Zlib.Portable" version="1.10.0" targetFramework="net40" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ https://developers.google.com/console/help/new/#generatingdevkeys
 https://console.developers.google.com/
 
 # Sample ExternalContentLibrary.xml #
-
+```xml
 <?xml version="1.0" encoding="utf-8" ?>
 <Configuration xmlns="http://www.sdltridion.com/ExternalContentLibrary/Configuration">
     <!-- Available logging levels: Debug, Info, Warning, Error -->

--- a/README.md
+++ b/README.md
@@ -30,9 +30,8 @@ https://console.developers.google.com/
             </StubFolders>
             <PrivilegedUserName>DOMAIN\user</PrivilegedUserName>
             <AppName xmlns="http://gdata.youtube.com/schemas/2007">Your YouTube App Name</AppName>
-            <DeveloperKey xmlns="http://gdata.youtube.com/schemas/2007">Your YouTube Developer Key</DeveloperKey>
+            <ApiKey xmlns="http://gdata.youtube.com/schemas/2007">Your YouTube Developer Key</ApiKey>
             <Username xmlns="http://gdata.youtube.com/schemas/2007">Your YouTube/Google Username</Username>
-            <Password xmlns="http://gdata.youtube.com/schemas/2007">Your YouTube/Google Password</Password>
             <Users xmlns="http://gdata.youtube.com/schemas/2007">
                 <User></User>
                 <User></User>

--- a/README.md
+++ b/README.md
@@ -2,4 +2,5 @@
 
 This is an External Content Library provider which exposes videos from YouTube in SDL Tridion 2013. The first version supports displaying videos from a single specified account, but could potentially be extended to allow search, multiple users, video upload and publishing in future.
 
+
 [https://www.sdltridionworld.com/community/2011_extensions/youtube_ecl_provider.aspx](https://www.sdltridionworld.com/community/2011_extensions/youtube_ecl_provider.aspx)

--- a/README.md
+++ b/README.md
@@ -32,13 +32,15 @@ https://console.developers.google.com/
             <AppName xmlns="http://gdata.youtube.com/schemas/2007">Your YouTube App Name</AppName>
             <ApiKey xmlns="http://gdata.youtube.com/schemas/2007">Your YouTube Developer Key</ApiKey>
             <Username xmlns="http://gdata.youtube.com/schemas/2007">Your YouTube/Google Username</Username>
+			<Password xmlns="http://gdata.youtube.com/schemas/2007">Your YouTube/Google Password</Password>
             <Users xmlns="http://gdata.youtube.com/schemas/2007">
-                <User></User>
-                <User></User>
+              <User></User>
+              <User></User>
             </Users>
+          <!--Use these entries only if you need to use proxy settings-->
             <ProxyURI xmlns="http://gdata.youtube.com/schemas/2007">Proxy Address</ProxyURI>
             <ProxyUser xmlns="http://gdata.youtube.com/schemas/2007">Proxy Username </ProxyUser>
-            <ProxyPassword xmlns="http://gdata.youtube.com/schemas/2007">Proxy Password</ProxyPassword>
+            <ProxyPassword xmlns="http://gdata.youtube.com/schemas/2007">Proxy Password</ProxyPassword>            
         </MountPoint>
     </MountPoints>
 </Configuration>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,45 @@
-# Tridion 2013 YouTube ECL Provider #
+# Tridion 2013 YouTube ECL Provider with google youtube v3 #
 
 This is an External Content Library provider which exposes videos from YouTube in SDL Tridion 2013. The first version supports displaying videos from a single specified account, but could potentially be extended to allow search, multiple users, video upload and publishing in future.
 
+# Updates #
+Supports multiple users/channels
+Supports proxy based access to youtube thumbnails
 
-[https://www.sdltridionworld.com/community/2011_extensions/youtube_ecl_provider.aspx](https://www.sdltridionworld.com/community/2011_extensions/youtube_ecl_provider.aspx)
+# Need Google Api Key to be generated -OAuth 2.0 #
+
+Please use below links to generate it
+
+https://developers.google.com/console/help/new/#generatingdevkeys
+https://console.developers.google.com/
+
+# Sample ExternalContentLibrary.xml #
+
+<?xml version="1.0" encoding="utf-8" ?>
+<Configuration xmlns="http://www.sdltridion.com/ExternalContentLibrary/Configuration">
+    <!-- Available logging levels: Debug, Info, Warning, Error -->
+    <l:Logging Level="Warning" xmlns:l="http://www.sdltridion.com/Infrastructure/LoggingConfiguration">
+        <!-- Additional supported attributes: Language="rfc1766 code" Locale="rfc1766 code". An example of an rfc1766 code is "de-DE" for German. /-->
+        <!-- <l:Folder>Full path to logging folder, default is %TRIDION%/bin/log</l:Folder>-->
+    </l:Logging>
+    <CoreServiceUrl>net.tcp://localhost:2660/CoreService/2011/netTcp</CoreServiceUrl>
+    <MountPoints>
+        <MountPoint type="YouTubeProvider" version="*" id="youtube" rootItemName="YouTube">
+            <StubFolders>
+                <StubFolder id="tcm:1-3-2" />
+            </StubFolders>
+            <PrivilegedUserName>DOMAIN\user</PrivilegedUserName>
+            <AppName xmlns="http://gdata.youtube.com/schemas/2007">Your YouTube App Name</AppName>
+            <DeveloperKey xmlns="http://gdata.youtube.com/schemas/2007">Your YouTube Developer Key</DeveloperKey>
+            <Username xmlns="http://gdata.youtube.com/schemas/2007">Your YouTube/Google Username</Username>
+            <Password xmlns="http://gdata.youtube.com/schemas/2007">Your YouTube/Google Password</Password>
+            <Users xmlns="http://gdata.youtube.com/schemas/2007">
+                <User></User>
+                <User></User>
+            </Users>
+            <ProxyURI xmlns="http://gdata.youtube.com/schemas/2007">Proxy Address</ProxyURI>
+            <ProxyUser xmlns="http://gdata.youtube.com/schemas/2007">Proxy Username </ProxyUser>
+            <ProxyPassword xmlns="http://gdata.youtube.com/schemas/2007">Proxy Password</ProxyPassword>
+        </MountPoint>
+    </MountPoints>
+</Configuration>

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# Tridion 2013 YouTube ECL Provider with google youtube v3 #
+# Tridion 2013 YouTube ECL Provider with google youtube v3 
 
 This is an External Content Library provider which exposes videos from YouTube in SDL Tridion 2013. The first version supports displaying videos from a single specified account, but could potentially be extended to allow search, multiple users, video upload and publishing in future.
 
-# Updates #
+### Updates 
 Supports multiple users/channels
 Supports proxy based access to youtube thumbnails
 
-# Need Google Api Key to be generated -OAuth 2.0 #
+### Need Google Api Key to be generated -OAuth 2.0 #
 
 Please use below links to generate it
 
 https://developers.google.com/console/help/new/#generatingdevkeys
 https://console.developers.google.com/
 
-# Sample ExternalContentLibrary.xml #
+### Sample ExternalContentLibrary.xml #
 ```xml
 <?xml version="1.0" encoding="utf-8" ?>
 <Configuration xmlns="http://www.sdltridion.com/ExternalContentLibrary/Configuration">


### PR DESCRIPTION
There are some issues with pagination
 -Google support maximum 50 results at a time
 -Google changed the way we were retrieving the list with pagination
 -With v3 google supports only forward and backward pagination, this works like some thing called as PageToken, and it is a token page index; It gets only with currently each request.
--I just added a work around for this, but its not good for a large list. let me know if anybody have better suggestion on this, so that I can update it

Also, added support for multi users and proxy based image thumbnail retrieval.
